### PR TITLE
 Fix unique_ptr_reset bug by ensuring atomic operation on is_owned variable

### DIFF
--- a/_posts/2024-10-12-Unique-Pointers-in-C.md
+++ b/_posts/2024-10-12-Unique-Pointers-in-C.md
@@ -70,18 +70,18 @@ T* unique_ptr_release_##T(unique_ptr_##T* up) { \
 \
 void unique_ptr_reset_##T(unique_ptr_##T *up, T *p)    \
     {                                                           \
-        if (atomic_load(&pointer->is_owned))                    \
+        if (atomic_load(&up->is_owned))                    \
         {                                                       \
             if (atomic_exchange(&up->is_owned, false))     \
             {                                                   \
                 if (up->ptr)                               \
                 {                                               \
-                    up->deleter(pointer->ptr);             \
+                    up->deleter(up->ptr);             \
                 }                                               \
             }                                                   \
         }                                                       \
         up->ptr = p;                                       \
-        atomic_store(&pointer->is_owned, p != NULL);            \
+        atomic_store(&up->is_owned, p != NULL);            \
     }                                                           \
                                                                 \
 unique_ptr_##T unique_ptr_move_##T(unique_ptr_##T* up) { \

--- a/_posts/2024-10-12-Unique-Pointers-in-C.md
+++ b/_posts/2024-10-12-Unique-Pointers-in-C.md
@@ -68,15 +68,22 @@ T* unique_ptr_release_##T(unique_ptr_##T* up) { \
     return tmp; \
 } \
 \
-void unique_ptr_reset_##T(unique_ptr_##T* up, T* p) { \
-    if (atomic_load(&up->is_owned)) { \
-        T* old = atomic_exchange(&up->ptr, p); \
-        if (old) { \
-            up->deleter(old); \
-        } \
-    } \
-} \
-\
+void unique_ptr_reset_##T(unique_ptr_##T *up, T *p)    \
+    {                                                           \
+        if (atomic_load(&pointer->is_owned))                    \
+        {                                                       \
+            if (atomic_exchange(&up->is_owned, false))     \
+            {                                                   \
+                if (up->ptr)                               \
+                {                                               \
+                    up->deleter(pointer->ptr);             \
+                }                                               \
+            }                                                   \
+        }                                                       \
+        up->ptr = p;                                       \
+        atomic_store(&pointer->is_owned, p != NULL);            \
+    }                                                           \
+                                                                \
 unique_ptr_##T unique_ptr_move_##T(unique_ptr_##T* up) { \
     unique_ptr_##T new_up = *up; \
     if (atomic_exchange(&up->is_owned, false)) { \


### PR DESCRIPTION
This PR addresses a concurrency bug in the `unique_ptr_reset_##T` macro implementation described in the article on [ unique pointers in C](https://mohitmishra786.github.io/chessman/2024/10/12/Unique-Pointers-in-C.html).

### 🐞 Problem

The original implementation used `atomic_exchange(&up->ptr, p)` and expected ownership logic to work correctly when resetting the pointer. However, it did **not properly synchronise** access to the `is_owned` flag, particularly when the unique pointer did **not** already own a value.

This introduces undefined behaviour due to the use of `atomic_exchange` on non-atomic variables, and also lacks safe transfer of ownership in a multi-threaded context.

### ✅ Solution
1. **Properly using `atomic_exchange()`** on the `is_owned` atomic flag to safely update ownership state.
2. Ensuring the old pointer value is deleted if it was owned.
3. Assigning the new pointer and updating ownership using `atomic_store()`.

### 📌 Updated Implementation

```c
void unique_ptr_reset_##T(unique_ptr_##T *pointer, T *p)
{
    if (atomic_load(&pointer->is_owned))
    {
        if (atomic_exchange(&pointer->is_owned, false))
        {
            if (pointer->ptr)
            {
                pointer->deleter(pointer->ptr);
            }
        }
    }

    pointer->ptr = p;
    atomic_store(&pointer->is_owned, p != NULL);
}
```

---

### 🔒 Benefits

* Proper synchronisation via atomic operations.
* Correct deletion of the old value if owned.
* Safe assignment of a new value with updated ownership semantics.